### PR TITLE
Re-inforcement agent - less no op

### DIFF
--- a/nidup/pysc2/actions.py
+++ b/nidup/pysc2/actions.py
@@ -26,6 +26,7 @@ _TRAIN_MARAUDER = actions.FUNCTIONS.Train_Marauder_quick.id
 
 _NOT_QUEUED = [0]
 _QUEUED = [1]
+_SELECT_ALL = [2]
 
 
 class TerranActionIds:
@@ -139,6 +140,9 @@ class TerranActions:
     def select_point(self, target) -> actions.FunctionCall:
         return actions.FunctionCall(_SELECT_POINT, [_NOT_QUEUED, target])
 
+    def select_point_all(self, target) -> actions.FunctionCall:
+        return actions.FunctionCall(_SELECT_POINT, [_SELECT_ALL, target])
+
     def select_rect(self, point1, point2) -> actions.FunctionCall:
         return actions.FunctionCall(_SELECT_RECT, [_NOT_QUEUED, point1, point2])
 
@@ -150,7 +154,7 @@ class TerranActions:
         return actions.FunctionCall(_SELECT_UNIT, [[1], [unit_index]])
 
     def train_marine(self) -> actions.FunctionCall:
-        return actions.FunctionCall(_TRAIN_MARINE, [_NOT_QUEUED])
+        return actions.FunctionCall(_TRAIN_MARINE, [_QUEUED])
 
     def train_marauder(self) -> actions.FunctionCall:
         return actions.FunctionCall(_TRAIN_MARAUDER, [_NOT_QUEUED])

--- a/nidup/pysc2/actions.py
+++ b/nidup/pysc2/actions.py
@@ -8,6 +8,7 @@ _BUILD_BARRACKS = actions.FUNCTIONS.Build_Barracks_screen.id
 _BUILD_TECHLAB_BARRACKS = actions.FUNCTIONS.Build_TechLab_screen.id
 _BUILD_REFINERY = actions.FUNCTIONS.Build_Refinery_screen.id
 _BUILD_FACTORY = actions.FUNCTIONS.Build_Factory_screen.id
+_HARVEST_GATHER = actions.FUNCTIONS.Harvest_Gather_screen.id
 _MORPH_ORBITAL_COMMAND = actions.FUNCTIONS.Morph_OrbitalCommand_quick.id
 _MOVE_MINIMAP = actions.FUNCTIONS.Move_minimap.id
 _MOVE_SCREEN = actions.FUNCTIONS.Move_screen.id
@@ -48,6 +49,9 @@ class TerranActionIds:
 
     def build_techlab_barracks(self) -> int:
         return _BUILD_TECHLAB_BARRACKS
+
+    def harvest_gather(self) -> int:
+        return _HARVEST_GATHER
 
     def move_camera(self) -> int:
         return _MOVE_CAMERA
@@ -99,6 +103,9 @@ class TerranActions:
 
     def build_techlab_barracks(self, target) -> actions.FunctionCall:
         return actions.FunctionCall(_BUILD_TECHLAB_BARRACKS, [_NOT_QUEUED, target])
+
+    def harvest_gather(self, target) -> actions.FunctionCall:
+        return actions.FunctionCall(_HARVEST_GATHER, [_QUEUED, target])
 
     def move_camera(self, target) -> actions.FunctionCall:
         return actions.FunctionCall(_MOVE_CAMERA, [target])

--- a/nidup/pysc2/observations.py
+++ b/nidup/pysc2/observations.py
@@ -212,7 +212,7 @@ class Observations:
         return self.control_groups_data
 
     def single_select(self):
-        return self.multi_select_data
+        return self.single_select_data
 
     def multi_select(self):
         return self.multi_select_data

--- a/nidup/pysc2/smart_agents.py
+++ b/nidup/pysc2/smart_agents.py
@@ -174,26 +174,18 @@ class ReinforcementAgent(BaseAgent):
                 return BuildMarine(self.location).train_marine(observations)
 
             elif smart_action == ACTION_ATTACK:
-                return Attack(self.location).attack_minimap(observations, x, y)
+                return Attack(self.location).attack_minimap(observations, int(x), int(y))
 
         elif self.move_number == 2:
             self.move_number = 0
 
             smart_action, x, y = self.splitAction(self.previous_action)
 
-            if smart_action == ACTION_BUILD_BARRACKS or smart_action == ACTION_BUILD_SUPPLY_DEPOT:
-                if _HARVEST_GATHER in obs.observation['available_actions']:
-                    unit_y, unit_x = (unit_type == _NEUTRAL_MINERAL_FIELD).nonzero()
+            if smart_action == ACTION_BUILD_SUPPLY_DEPOT:
+                return BuildSupplyDepot(self.location).send_scv_to_mineral(observations)
 
-                    if unit_y.any():
-                        i = random.randint(0, len(unit_y) - 1)
-
-                        m_x = unit_x[i]
-                        m_y = unit_y[i]
-
-                        target = [int(m_x), int(m_y)]
-
-                        return actions.FunctionCall(_HARVEST_GATHER, [_QUEUED, target])
+            elif smart_action == ACTION_BUILD_BARRACKS:
+                return BuildBarracks(self.location).send_scv_to_mineral(observations)
 
         return actions.FunctionCall(_NO_OP, [])
 

--- a/nidup/pysc2/smart_orders.py
+++ b/nidup/pysc2/smart_orders.py
@@ -1,6 +1,5 @@
 
 import random
-import math
 from pysc2.lib import actions
 from nidup.pysc2.actions import TerranActions, TerranActionIds
 from nidup.pysc2.observations import Observations
@@ -21,7 +20,7 @@ class Location:
         unit_type = observations.screen().unit_type()
         self.cc_y, self.cc_x = (unit_type == UnitTypeIds().terran_command_center()).nonzero()
 
-    def top_left(self):
+    def command_center_is_top_left(self) -> bool:
         return self.base_top_left
 
     def command_center_position(self):
@@ -163,3 +162,9 @@ class Attack(SmartOrder):
             return self.actions.attack_minimap(target)
 
         return self.actions.no_op()
+
+
+class NoOrder:
+
+    def do_nothing(self) -> actions.FunctionCall:
+        return TerranActions().no_op()

--- a/nidup/pysc2/smart_orders.py
+++ b/nidup/pysc2/smart_orders.py
@@ -1,0 +1,143 @@
+
+import random
+import math
+from pysc2.lib import actions
+from nidup.pysc2.actions import TerranActions, TerranActionIds
+from nidup.pysc2.observations import Observations
+from nidup.pysc2.unit_types import UnitTypeIds
+
+# Parameters
+_PLAYER_SELF = 1
+
+
+class Location:
+
+    base_top_left = None
+    unit_type_ids = None
+
+    def __init__(self, observations: Observations):
+        player_y, player_x = (observations.minimap().player_relative() == _PLAYER_SELF).nonzero()
+        self.base_top_left = player_y.mean() <= 31
+        unit_type = observations.screen().unit_type()
+        self.cc_y, self.cc_x = (unit_type == UnitTypeIds().terran_command_center()).nonzero()
+
+    def top_left(self):
+        return self.base_top_left
+
+    def command_center_position(self):
+        return self.cc_x, self.cc_y
+
+    def transform_distance(self, x, x_distance, y, y_distance):
+        if not self.base_top_left:
+            return [x - x_distance, y - y_distance]
+
+        return [x + x_distance, y + y_distance]
+
+    def transform_location(self, x, y):
+        if not self.base_top_left:
+            return [64 - x, 64 - y]
+
+        return [x, y]
+
+
+class SmartOrder:
+    def __init__(self, location: Location):
+        self.location = location
+        self.actions = TerranActions()
+        self.action_ids = TerranActionIds()
+        self.unit_type_ids = UnitTypeIds()
+
+
+class BuildBarracks(SmartOrder):
+
+    def select_scv(self, observations: Observations) -> actions.FunctionCall:
+        unit_type = observations.screen().unit_type()
+        unit_y, unit_x = (unit_type == self.unit_type_ids.terran_scv()).nonzero()
+        if unit_y.any():
+            i = random.randint(0, len(unit_y) - 1)
+            target = [unit_x[i], unit_y[i]]
+            return self.actions.select_point(target)
+
+        return self.actions.no_op()
+
+    def build(self, observations: Observations) -> actions.FunctionCall:
+        unit_type = observations.screen().unit_type()
+        cc_x, cc_y = self.location.command_center_position()
+        barracks_y, barracks_x = (unit_type == self.unit_type_ids.terran_barracks()).nonzero()
+        barracks_count = int(round(len(barracks_y) / 137))
+        if barracks_count < 2 and self.action_ids.build_barracks() in observations.available_actions():
+            if cc_y.any():
+                if barracks_count == 0:
+                    target = self.location.transform_distance(round(cc_x.mean()), 15, round(cc_y.mean()), -9)
+                elif barracks_count == 1:
+                    target = self.location.transform_distance(round(cc_x.mean()), 15, round(cc_y.mean()), 12)
+                return self.actions.build_barracks(target)
+        return self.actions.no_op()
+
+
+class BuildSupplyDepot(SmartOrder):
+
+    def select_scv(self, observations: Observations) -> actions.FunctionCall:
+        unit_type = observations.screen().unit_type()
+        unit_y, unit_x = (unit_type == self.unit_type_ids.terran_scv()).nonzero()
+        if unit_y.any():
+            i = random.randint(0, len(unit_y) - 1)
+            target = [unit_x[i], unit_y[i]]
+            return self.actions.select_point(target)
+        return self.actions.no_op()
+
+    def build(self, observations: Observations) -> actions.FunctionCall:
+        unit_type = observations.screen().unit_type()
+        cc_x, cc_y = self.location.command_center_position()
+        depot_y, depot_x = (unit_type == self.unit_type_ids.terran_supply_depot()).nonzero()
+        supply_depot_count = int(round(len(depot_y) / 69))
+        if supply_depot_count < 2 and self.action_ids.build_supply_depot() in observations.available_actions():
+            if cc_y.any():
+                if supply_depot_count == 0:
+                    target = self.location.transform_distance(round(cc_x.mean()), -35, round(cc_y.mean()), 0)
+                elif supply_depot_count == 1:
+                    target = self.location.transform_distance(round(cc_x.mean()), -25, round(cc_y.mean()), -25)
+                return self.actions.build_supply_depot(target)
+        return self.actions.no_op()
+
+
+class BuildMarine(SmartOrder):
+
+    def select_barracks(self, observations: Observations) -> actions.FunctionCall:
+        unit_type = observations.screen().unit_type()
+        barracks_y, barracks_x = (unit_type == self.unit_type_ids.terran_barracks()).nonzero()
+        if barracks_y.any():
+            i = random.randint(0, len(barracks_y) - 1)
+            target = [barracks_x[i], barracks_y[i]]
+            return self.actions.select_point_all(target)
+        return self.actions.no_op()
+
+    def train_marine(self, observations: Observations) -> actions.FunctionCall:
+        if self.action_ids.train_marine() in observations.available_actions():
+            return self.actions.train_marine()
+        return self.actions.no_op()
+
+
+class Attack(SmartOrder):
+
+    def select_army(self, observations: Observations) -> actions.FunctionCall:
+        if self.action_ids.select_army() in observations.available_actions():
+            return self.actions.select_army()
+
+        return self.actions.no_op()
+
+    def attack_minimap(self, observations: Observations, x, y) -> actions.FunctionCall:
+        do_it = True
+        if len(observations.single_select()) > 0 and observations.single_select()[0][0] == self.unit_type_ids.terran_scv():
+            do_it = False
+
+        if len(observations.multi_select()) > 0 and observations.multi_select()[0][0] == self.unit_type_ids.terran_scv():
+            do_it = False
+
+        if do_it and self.action_ids.attack_minimap() in observations.available_actions():
+            x_offset = random.randint(-1, 1)
+            y_offset = random.randint(-1, 1)
+            target = self.location.transform_location(int(x) + (x_offset * 8), int(y) + (y_offset * 8))
+            return self.actions.attack_minimap(target)
+
+        return self.actions.no_op()

--- a/nidup/pysc2/unit_types.py
+++ b/nidup/pysc2/unit_types.py
@@ -8,11 +8,14 @@ _TERRAN_FACTORY = 27
 _TERRAN_SCV = 45
 _TERRAN_ORBITALCOMMAND = 132
 _TERRAN_BARRACKSTECHLAB = 37
-_NEUTRAL_MINERALFIELD = 341
+_NEUTRAL_MINERAL_FIELD = 341
 _NEUTRAL_VESPENE_GEYSER = 342
 
 
 class UnitTypeIds:
+
+    def neutral_mineral_field(self) -> int:
+        return _NEUTRAL_MINERAL_FIELD
 
     def neutral_vespene_geyser(self) -> int:
         return _NEUTRAL_VESPENE_GEYSER

--- a/nidup/pysc2/unit_types.py
+++ b/nidup/pysc2/unit_types.py
@@ -37,3 +37,6 @@ class UnitTypeIds:
 
     def terran_refinery(self) -> int:
         return _TERRAN_REFINERY
+
+    def terran_supply_depot(self) -> int:
+        return _TERRAN_SUPPLYDEPOT


### PR DESCRIPTION
Refactor ReinforcementAgent to remove the systematic 3 step actions per smart action.
We reduce the amount of no operation actions.
Introduce the concept of smart order to make easier to add some new order.
This change improves by 10% the amount of not lost games.

Before:
 - Build supply depot = 3 actions
 - Build barracks = 3 actions
 - Build marine = 3 actions (one doing nothing)
 - Attack = 3 actions (one doing nothing)

After:
 - Build supply depot = 3 actions
 - Build barracks = 3 actions
 - Build marine = 2 actions
 - Attack = 2 actions

Before: 300 games of training to lose 60% of the episodes in average
![nidup pysc2 smart_agents reinforcementagent_results](https://user-images.githubusercontent.com/2104359/36943994-5cbb1aae-1f93-11e8-90ae-ec281852abb7.png)

After: 300 games of training to lose 50% of the episodes in average
![nidup pysc2 smart_agents reinforcementagent_results](https://user-images.githubusercontent.com/2104359/36944009-9ce35dee-1f93-11e8-930c-49f20d523774.png)

After: 800 games of training, the loose average is still around 50% with more draw games:
![nidup pysc2 smart_agents reinforcementagent_results](https://user-images.githubusercontent.com/2104359/36944001-6d5fddf4-1f93-11e8-8eb4-4c11f495ec59.png)
