### PR TITLE
Remove attack own base from available actions

### DIFF
--- a/nidup/pysc2/agent/smart/commander.py
+++ b/nidup/pysc2/agent/smart/commander.py
@@ -37,9 +37,8 @@ class SmartActions:
                     attack_actions.append(ACTION_ATTACK + '_' + str(mm_x - 16) + '_' + str(mm_y - 16))
         # remove the player's base quadrant
         del attack_actions[0]
-        # remove other base quadrants (keep only enemy's one)
-        del attack_actions[0]
-        del attack_actions[0]
+        # keep only enemy's base 1 and base 2 quadrants (natural expansion)
+        del attack_actions[1]
         self.actions = self.actions + attack_actions
 
     def all(self) -> []:

--- a/nidup/pysc2/agent/smart/commander.py
+++ b/nidup/pysc2/agent/smart/commander.py
@@ -37,6 +37,9 @@ class SmartActions:
                     attack_actions.append(ACTION_ATTACK + '_' + str(mm_x - 16) + '_' + str(mm_y - 16))
         # remove the player's base quadrant
         del attack_actions[0]
+        # remove other base quadrants (keep only enemy's one)
+        del attack_actions[0]
+        del attack_actions[0]
         self.actions = self.actions + attack_actions
 
     def all(self) -> []:

--- a/nidup/pysc2/agent/smart/commander.py
+++ b/nidup/pysc2/agent/smart/commander.py
@@ -21,7 +21,8 @@ ACTION_ATTACK = 'attack'
 
 class SmartActions:
 
-    def __init__(self):
+    def __init__(self, location: Location):
+        self.location = location
         self.actions = [
             ACTION_DO_NOTHING,
             ACTION_BUILD_SUPPLY_DEPOT,
@@ -29,24 +30,28 @@ class SmartActions:
             ACTION_BUILD_MARINE
         ]
         # split the mini-map into four quadrants keep the action space small to make it easier for the agent to learn
+        attack_actions = []
         for mm_x in range(0, 64):
             for mm_y in range(0, 64):
                 if (mm_x + 1) % 32 == 0 and (mm_y + 1) % 32 == 0:
-                    self.actions.append(ACTION_ATTACK + '_' + str(mm_x - 16) + '_' + str(mm_y - 16))
+                    attack_actions.append(ACTION_ATTACK + '_' + str(mm_x - 16) + '_' + str(mm_y - 16))
+        # remove the player's base quadrant
+        del attack_actions[0]
+        self.actions = self.actions + attack_actions
 
     def all(self) -> []:
         return self.actions
 
-    def order(self, action_id: str, location: Location) -> Order:
+    def order(self, action_id: str) -> Order:
         smart_action, x, y = self._split_action(action_id)
         if smart_action == ACTION_BUILD_BARRACKS:
-            return BuildBarracks(location)
+            return BuildBarracks(self.location)
         elif smart_action == ACTION_BUILD_SUPPLY_DEPOT:
-            return BuildSupplyDepot(location)
+            return BuildSupplyDepot(self.location)
         elif smart_action == ACTION_BUILD_MARINE:
-            return BuildMarine(location)
+            return BuildMarine(self.location)
         elif smart_action == ACTION_ATTACK:
-            return Attack(location, int(x), int(y))
+            return Attack(self.location, int(x), int(y))
         elif smart_action == ACTION_DO_NOTHING:
             return NoOrder()
         else:
@@ -101,9 +106,8 @@ class QLearningCommander(Commander):
     def __init__(self, agent_name: str):
         super(Commander, self).__init__()
         self.agent_name = agent_name
-        self.smart_actions = SmartActions()
-        self.qlearn = QLearningTable(actions=list(range(len(self.smart_actions.all()))))
-        QLearningTableStorage().load(self.qlearn, self.agent_name)
+        self.smart_actions = None
+        self.qlearn = None
         self.previous_action = None
         self.previous_state = None
         self.previous_order = None
@@ -125,6 +129,9 @@ class QLearningCommander(Commander):
 
         elif observations.first():
             self.location = Location(observations)
+            self.smart_actions = SmartActions(self.location)
+            self.qlearn = QLearningTable(actions=list(range(len(self.smart_actions.all()))))
+            QLearningTableStorage().load(self.qlearn, self.agent_name)
 
         if not self.previous_order or self.previous_order.done(observations):
 
@@ -137,6 +144,6 @@ class QLearningCommander(Commander):
 
             self.previous_state = current_state
             self.previous_action = rl_action
-            self.previous_order = self.smart_actions.order(rl_action, self.location)
+            self.previous_order = self.smart_actions.order(rl_action)
 
         return self.previous_order


### PR DESCRIPTION
Before (attacking all quadrants):

![36946127-4f52e4a8-1fb8-11e8-97ae-eb7f5a6c1179](https://user-images.githubusercontent.com/2104359/36946856-c4d90044-1fc3-11e8-8529-975ebdb3092d.png)

After (remove attack own player's base from available actions) :

![nidup pysc2 smart_agents reinforcementagent_results](https://user-images.githubusercontent.com/2104359/36946869-0b3c68be-1fc4-11e8-8b0f-de30af506cdc.png)

After (attack only enemy's base 1) :

![nidup pysc2 smart_agents reinforcementagent_results](https://user-images.githubusercontent.com/2104359/36947906-ab9ab4e2-1fd2-11e8-9464-1ff1a0301c29.png)

After (attack only enemy's base 1 or 2):
![nidup pysc2 smart_agents reinforcementagent_results](https://user-images.githubusercontent.com/2104359/36949467-2332e388-1fe9-11e8-8345-6437a59c32ce.png)
